### PR TITLE
Set-Window PassThru logic bug

### DIFF
--- a/Set-Window.psm1
+++ b/Set-Window.psm1
@@ -97,7 +97,7 @@ Function Set-Window {
         If ($Return) {
             $Return = [Window]::MoveWindow($Handle, $x, $y, $Width, $Height,$True)
         }
-        If ($PSBoundParameters.ContainsKey('Passthru')) {
+        If ($Passthru.IsPresent) {
             $Rectangle = New-Object RECT
             $Return = [Window]::GetWindowRect($Handle,[ref]$Rectangle)
             If ($Return) {

--- a/Set-Window.psm1
+++ b/Set-Window.psm1
@@ -27,13 +27,16 @@ Function Set-Window {
             Display the output object of the window.
 
         .NOTES
+            Taken from https://github.com/brad-do/ps-miscellany/blob/master/Set-Window.psm1
+            [73ef6c4]...who appears to have taken it from:
+
             Name: Set-Window
             Author: Boe Prox
             Version History
                 1.0//Boe Prox - 11/24/2015
                     - Initial build
 
-        .OUTPUT
+        .OUTPUTS
             System.Automation.WindowInfo
 
         .EXAMPLE

--- a/Set-Window.psm1
+++ b/Set-Window.psm1
@@ -55,6 +55,7 @@ Function Set-Window {
     [cmdletbinding()]
     Param (
         [parameter(ValueFromPipelineByPropertyName=$True)]
+        [Alias('Id')]
         $ProcessId,
         [int]$X,
         [int]$Y,

--- a/Set-Window.psm1
+++ b/Set-Window.psm1
@@ -88,10 +88,10 @@ Function Set-Window {
         $Rectangle = New-Object RECT
         $Handle = (Get-Process -Id $ProcessId).MainWindowHandle
         $Return = [Window]::GetWindowRect($Handle,[ref]$Rectangle)
-        If (-NOT $PSBoundParameters.ContainsKey('Width')) {            
+        If ($null -eq $Width) {            
             $Width = $Rectangle.Right - $Rectangle.Left            
         }
-        If (-NOT $PSBoundParameters.ContainsKey('Height')) {
+        If ($null -eq $Height) {
             $Height = $Rectangle.Bottom - $Rectangle.Top
         }
         If ($Return) {


### PR DESCRIPTION
Hello Sir, 
I like your function. I can suggest fixing an issue you have with the PassThru parameter. You utilize the `ContainsKey` hashtable method to conditionalize it, but this can have unexpected results since it's not looking at the value, but rather if the parameter was specified. 

Here is a short example of why this matters:

    PS> function test2 {

        param([switch]$passthru)
        If ($PSBoundParameters.ContainsKey('Passthru')) {
            echo 'passing thru'
        }
    }

    PS> test2

    PS> test2 -passthru
    passing thru

    PS> test2 -passthru:$true
    passing thru

    PS> test2 -passthru:$false
    passing thru

Your logic is

    If ($PSBoundParameters.ContainsKey('Passthru')) { ... }

The correct logic should be 

    If ($PassThru.IsPresent) { ... }

You used this method a few times, in this function. I forked this and made a PR for you, but this repo is a bit older--as is your last activity, so I won't hold my breath. 

Thanks again for building this function. I'm going to make a script for my work laptop so it shows the same layout at home vs the office with different resolutions, but on the same number of screens. 

[EDIT: typo]